### PR TITLE
Added tests for motion interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,11 @@ repos:
     rev: v4.3.21
     hooks:
     -   id: isort
-        args: ["--recursive"]
+        args: ["--recursive", "--verbose"]
         additional_dependencies: [toml]
+        # need to exclude files here as isort in pre-commit hook doesn't seem
+        # to look for config in pyproject.toml
+        exclude: (rokku\.py|raspberry_pi_camera\/tests\/|raspberry_pi_motion_sensor\/tests)
 -   repo: https://github.com/psf/black
     rev: stable
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ install:
   - pip3 install -r requirements.txt
   - pip3 install flake8
   - pip3 install black
+  - pip3 install isort
 
 script:
   - flake8 .
-  - black --check --verbose .
+  - isort --recursive --check
+  - black --check .
   # test non-ui code
   - python3 -m pytest --ignore=src/raspberry_pi_ui/tests
   # use xvfb to test ui code without spinning up ui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ exclude = '''
 
 [tool.isort]
 line_length = 79
+skip = "rokku.py"
+skip_glob = ["*/venv/*", "*/raspberry_pi_camera/tests/*", "*/raspberry_pi_motion_sensor/tests/*"]
 known_future_library = ["future", "pies"]
 known_third_party = ["RPi", "fake_rpi", "gi", "paho", "picamera", "publisher", "pytest", "subscriber", "yaml"]
 indent = "    "

--- a/src/pi_to_pi/publisher.py
+++ b/src/pi_to_pi/publisher.py
@@ -1,9 +1,10 @@
-import paho.mqtt.client as mqtt
-from time import sleep
 import logging
 import logging.config
-import yaml
 import os
+from time import sleep
+
+import paho.mqtt.client as mqtt
+import yaml
 
 
 class Publisher:

--- a/src/pi_to_pi/subscriber.py
+++ b/src/pi_to_pi/subscriber.py
@@ -1,9 +1,10 @@
-import paho.mqtt.client as mqtt
-from time import sleep
 import logging
 import logging.config
-import yaml
 import os
+from time import sleep
+
+import paho.mqtt.client as mqtt
+import yaml
 
 
 class Subscriber:

--- a/src/pi_to_pi/tests/communication_sample.py
+++ b/src/pi_to_pi/tests/communication_sample.py
@@ -1,13 +1,14 @@
 import os
 import sys
+from multiprocessing import Process, Queue
+from time import sleep
+
+import publisher
+import subscriber
 
 # add parent dir to sys path such that we can import modules from parent dir
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import publisher
-import subscriber
-from time import sleep
-from multiprocessing import Process, Queue
 
 """
 This code serves as an example for communication between two devices via mqtt.

--- a/src/pi_to_pi/tests/test_mqtt_client.py
+++ b/src/pi_to_pi/tests/test_mqtt_client.py
@@ -1,9 +1,10 @@
-from .. import publisher, subscriber
 import json
-from time import sleep
-from multiprocessing import Process, Queue
-import re
 import os
+import re
+from multiprocessing import Process, Queue
+from time import sleep
+
+from .. import publisher, subscriber
 
 
 def test_pub_sub():

--- a/src/raspberry_pi_camera/camera_interface.py
+++ b/src/raspberry_pi_camera/camera_interface.py
@@ -1,8 +1,9 @@
-from picamera import PiCamera
 import datetime
+import socket
 import subprocess
 from time import sleep
-import socket
+
+from picamera import PiCamera
 
 """class to hold everything goes here..."""
 

--- a/src/raspberry_pi_camera/tests/test_camera_interface.py
+++ b/src/raspberry_pi_camera/tests/test_camera_interface.py
@@ -1,9 +1,11 @@
 import sys
+
 import fake_rpi
 
 sys.modules["picamera"] = fake_rpi.picamera  # Fake picamera
 
 from .. import camera_interface  # from .. import camera_interface
+
 
 """import os"""
 

--- a/src/raspberry_pi_motion_sensor/motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/motion_interface.py
@@ -54,7 +54,7 @@ class MotionPir:
         self.armed = False
         GPIO.remove_event_detect(self.channel_num)
 
-    def show_state(self):
+    def get_state(self):
         """Returnss the state of armed / 'alarm system' """
 
         if self.armed:

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -3,11 +3,10 @@ from multiprocessing import Queue
 
 import fake_rpi
 
-from .. import motion_interface
-
 sys.modules["RPi"] = fake_rpi.RPi
 sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
+from .. import motion_interface
 
 queue = Queue()
 motion = motion_interface.MotionPir(queue, 23)

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -8,6 +8,7 @@ sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
 from .. import motion_interface
 
+
 queue = Queue()
 motion = motion_interface.MotionPir(queue, 23)
 

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -1,0 +1,48 @@
+import sys
+from multiprocessing import Queue
+
+import fake_rpi
+
+from .. import motion_interface
+
+sys.modules["RPi"] = fake_rpi.RPi
+sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
+
+queue = Queue()
+motion = motion_interface.MotionPir(queue, 23)
+
+
+class TestMotionPir:
+    def test_init(self):
+        assert motion.channel_num == 23
+
+    def test_init_2(self):
+        assert motion.queue.qsize() == 0
+
+    def test_init_3(self):
+        assert motion.armed is False
+
+    def test_set_disarmed(self):
+        motion.set_armed()
+        motion.set_disarmed()
+        assert motion.armed is False
+
+    def test_set_armed(self):
+        motion.set_disarmed()
+        motion.set_armed()
+        assert motion.armed is True
+
+    def test_motion_callback(self):
+        motion.motion_callback(23)
+        result = motion.queue.get()
+        assert result is True
+
+    def test_get_state(self):
+        motion.set_disarmed()
+        motion.set_armed()
+        result = motion.get_state()
+        assert result is True
+
+    def test_get_state2(self):
+        result = motion.get_state()
+        assert result is True

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -1,9 +1,12 @@
 import sys
 from multiprocessing import Queue
+
 import fake_rpi
+
+from .. import motion_interface
+
 sys.modules["RPi"] = fake_rpi.RPi
 sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
-from .. import motion_interface
 
 
 queue = Queue()

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -2,11 +2,11 @@ import sys
 from multiprocessing import Queue
 
 import fake_rpi
+sys.modules["RPi"] = fake_rpi.RPi
+sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
 from .. import motion_interface
 
-sys.modules["RPi"] = fake_rpi.RPi
-sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
 queue = Queue()
 motion = motion_interface.MotionPir(queue, 23)

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -2,10 +2,11 @@ import sys
 from multiprocessing import Queue
 
 import fake_rpi
-sys.modules["RPi"] = fake_rpi.RPi
-sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
 from .. import motion_interface
+
+sys.modules["RPi"] = fake_rpi.RPi
+sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
 
 
 queue = Queue()

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -1,12 +1,9 @@
 import sys
 from multiprocessing import Queue
-
 import fake_rpi
-
-from .. import motion_interface
-
 sys.modules["RPi"] = fake_rpi.RPi
 sys.modules["RPi.GPIO"] = fake_rpi.RPi.GPIO
+from .. import motion_interface
 
 
 queue = Queue()

--- a/src/raspberry_pi_ui/Sample_GUI/main.py
+++ b/src/raspberry_pi_ui/Sample_GUI/main.py
@@ -1,8 +1,9 @@
 import os
+
 import gi
+from gi.repository import Gtk as gtk
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk as gtk
 
 gladeFile = "main.glade"
 

--- a/src/raspberry_pi_ui/Sample_GUI/test.py
+++ b/src/raspberry_pi_ui/Sample_GUI/test.py
@@ -1,7 +1,7 @@
 import gi
+from gi.repository import Gtk as gtk
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk as gtk
 
 
 class Main:

--- a/src/raspberry_pi_ui/Sample_GUI/ui.py
+++ b/src/raspberry_pi_ui/Sample_GUI/ui.py
@@ -1,9 +1,9 @@
 import os
-import gi
 
+import gi
+from gi.repository import Gdk, Gtk
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk
 
 
 class Main:

--- a/src/raspberry_pi_ui/rokku.py
+++ b/src/raspberry_pi_ui/rokku.py
@@ -6,10 +6,12 @@ from time import time
 
 import gi
 import yaml
-from gi.repository import Gdk as gdk
-from gi.repository import Gtk as gtk
 
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+
+from gi.repository import Gdk as gdk
+from gi.repository import Gtk as gtk
 
 
 # Any global variables that should be used throughout file


### PR DESCRIPTION
The order of imports before black formatting below passed pytest:

import fake_rpi
sys.modules['RPi'] = fake_rpi.RPi
sys.modules['RPi.GPIO'] = fake_rpi.RPi.GPIO
from .. import motion_interface

The new order from formatting checks may not work
