### PR TITLE
Curtis woodworth/behavior shell

### DIFF
--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -7,7 +7,7 @@ import RPi.GPIO as GPIO
 import yaml
 
 from src.pi_to_pi.utility import set_up_pub_sub
-from src.raspberry_pi_driver import behaviors
+from src.raspberry_pi_driver.behaviors import (motion, intercom, record, alarm)
 from src.raspberry_pi_driver.utility import (
     command_line_parser,
     hash_prefix,
@@ -39,8 +39,14 @@ def main():
                 msg: str = msg_q.get()
                 print(f"Sample behavior received: {msg}")
                 identifier, flag = json.loads(msg)
+                if identifier == "alarm":
+                    alarm(pub, flag)
+                if identifier == "intercom":
+                    intercom(pub, flag)
                 if identifier == "motion":
-                    behaviors.motion(pub, flag)
+                    motion(pub, flag)
+                if identifier == "record":
+                    record(pub, flag)
             sleep(1)
     except (KeyboardInterrupt, SystemExit):
         logger.warning("Termination signal sensed.")

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -1,7 +1,7 @@
 import logging
 import logging.config
 from time import sleep
-
+import json
 import yaml
 
 from src.pi_to_pi.utility import set_up_pub_sub

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -2,7 +2,7 @@ import json
 import logging
 import logging.config
 from time import sleep
-
+from multiprocessing import Queue
 import RPi.GPIO as GPIO
 import yaml
 
@@ -32,6 +32,7 @@ def main():
     logger.info("Setting up publisher and subscriber")
     pub, msg_q, listen_proc = set_up_pub_sub(prefix, "out_to_in", "in_to_out")
     logger.info("Publisher and subscriber set up successfully!")
+    motion_queue = Queue()
     try:
         # forever listening on topic "Rokku/in_to_out"
         while True:
@@ -44,7 +45,7 @@ def main():
                 if identifier == "intercom":
                     intercom(pub, flag)
                 if identifier == "motion":
-                    motion(pub, flag)
+                    motion(pub, flag, motion_queue)
                 if identifier == "record":
                     record(pub, flag)
             sleep(1)

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -3,6 +3,7 @@ import logging.config
 from time import sleep
 import json
 import yaml
+import RPi.GPIO as GPIO
 
 from src.pi_to_pi.utility import set_up_pub_sub
 from src.raspberry_pi_driver.behaviors import (motion)
@@ -18,6 +19,10 @@ with open("logger_config.yaml", "r") as f:
     logging.config.dictConfig(config)
 logger = logging.getLogger("RPI_OUT")
 
+# set up RPi board
+GPIO.setmode(
+    GPIO.BCM
+)  # use GPIO.setmode(GPIO.board) for using pin numbers
 
 def main():
     # parse command line argument
@@ -43,6 +48,7 @@ def main():
         terminate_proc(listen_proc)
         logger.info(f"{listen_proc.name} terminated successfully!")
     logger.info("\n******* rpi_out_driver ends *******\n")
+    GPIO.cleanup()
 
 
 if __name__ == "__main__":

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -5,7 +5,7 @@ from time import sleep
 import yaml
 
 from src.pi_to_pi.utility import set_up_pub_sub
-from src.raspberry_pi_driver.behaviors import sample
+from src.raspberry_pi_driver.behaviors import (motion)
 from src.raspberry_pi_driver.utility import (
     command_line_parser,
     hash_prefix,
@@ -31,8 +31,11 @@ def main():
         # forever listening on topic "Rokku/in_to_out"
         while True:
             if not msg_q.empty():
-                # code behaviors
-                sample(msg_q, pub)
+                msg: str = msg_q.get()
+                print(f"Sample behavior received: {msg}")
+                identifier, flag = json.loads(msg)
+                if identifier is "motion":
+                    motion(pub, flag)              
             sleep(1)
     except (KeyboardInterrupt, SystemExit):
         logger.warning("Termination signal sensed.")

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -7,7 +7,7 @@ import RPi.GPIO as GPIO
 import yaml
 
 from src.pi_to_pi.utility import set_up_pub_sub
-from src.raspberry_pi_driver.behaviors import (motion, intercom, record, alarm)
+from src.raspberry_pi_driver.behaviors import alarm, intercom, motion, record
 from src.raspberry_pi_driver.utility import (
     command_line_parser,
     hash_prefix,

--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -1,8 +1,9 @@
 import json
 import logging
 import logging.config
-from time import sleep
 from multiprocessing import Queue
+from time import sleep
+
 import RPi.GPIO as GPIO
 import yaml
 

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -1,6 +1,6 @@
 import json
 from time import sleep
-
+from src.raspberry_pi_motion_sensor.motion_interface import MotionPIR
 
 def sample(msg_q, pub) -> None:
     """
@@ -22,3 +22,12 @@ def sample(msg_q, pub) -> None:
     identifier, flag = json.loads(msg)
     sleep(1)
     pub.publish(json.dumps([identifier, flag]))
+
+def motion(pub, flag):
+    motion = MotionPIR(None, 23)
+    if flag is True:
+        motion.set_armed()
+    else:
+        motion.set_disarmed()
+    pub.publish(json.dumps(["motion", motion.get_state()]))
+

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -1,5 +1,5 @@
 import json
-from time import sleep
+
 from ..raspberry_pi_motion_sensor.motion_interface import MotionPir
 
 
@@ -12,23 +12,29 @@ def motion(pub, flag) -> None:
         sensor.set_disarmed()
     pub.publish(json.dumps(["motion", sensor.get_state()]))
 
+
 def intercom(pub, flag) -> None:
     """Behavior that will connect or disconnect rpi_out with mumble client."""
     if flag is True:
         pass  # set up intercom for rpi_out
+        pub.publish(json.dumps(["intercom", True]))
     else:
         pass  # disconnect intercom
-    pub.publish(json.dumps(["intercom", False]))  # Change False to state of intercom
+        pub.publish(json.dumps(["intercom", False]))
+
 
 def record(pub, flag) -> None:
     """Behavior that will record a video, upload it to YouTube, and publish an URL to rpi_in."""
     if flag is True:
         # Start recording.
-        pub.publish(json.dumps(["record", True]))  # Will change button color, assuming video is being recorded.
+        pub.publish(
+            json.dumps(["record", True])
+        )  # Will change button color, assuming video is being recorded.
         # Once recording is over and YouTube gives link to playlist
-        pub.publish(json.dumps(["yt_playlist_link"]))
+        pub.publish(json.dumps(["yt_playlist_link", True]))
     else:
         pub.publish(json.dumps(["record", False]))  # Something went wrong
+
 
 def alarm(pub, flag) -> None:
     """Behavior that will set off alarm on rpi_out."""

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -3,9 +3,9 @@ import json
 from ..raspberry_pi_motion_sensor.motion_interface import MotionPir
 
 
-def motion(pub, flag) -> None:
+def motion(pub, flag, queue) -> None:
     """Behavior that will arm or disarm the motion sensor."""
-    sensor = MotionPir(None, 23)
+    sensor = MotionPir(queue, 23)
     if flag is True:
         sensor.set_armed()
     else:

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -1,6 +1,6 @@
 import json
 from time import sleep
-from src.raspberry_pi_motion_sensor.motion_interface import MotionPIR
+from ..raspberry_pi_motion_sensor.motion_interface import MotionPir
 
 def sample(msg_q, pub) -> None:
     """

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -1,44 +1,38 @@
 import json
 from time import sleep
-
 from ..raspberry_pi_motion_sensor.motion_interface import MotionPir
 
 
-def sample(msg_q, pub) -> None:
-    """
-    A sample behavior upon getting message form msg_q. This function can ONLY
-    be called if there is something in the msg_q already. Sample behavior
-    prints out the received message, and send back a message containing the
-    same content.
-
-    Args:
-        msg_q:      The queue connecting this process to listen_proc
-        pub:        Publisher for publishing MQTT message
-    Returns:
-        None
-    Raises:
-        None
-    """
-    msg: str = msg_q.get()
-    print(f"Sample behavior received: {msg}")
-    identifier, flag = json.loads(msg)
-    sleep(1)
-    pub.publish(json.dumps([identifier, flag]))
-
-<<<<<<< HEAD
-def motion(pub, flag):
-    sensor = MotionPIR(None, 23)
-=======
-
 def motion(pub, flag) -> None:
+    """Behavior that will arm or disarm the motion sensor."""
     sensor = MotionPir(None, 23)
->>>>>>> 54d2abcf4d11d2e05b177f7ea1bcc769685b003f
     if flag is True:
         sensor.set_armed()
     else:
         sensor.set_disarmed()
     pub.publish(json.dumps(["motion", sensor.get_state()]))
-<<<<<<< HEAD
 
-=======
->>>>>>> 54d2abcf4d11d2e05b177f7ea1bcc769685b003f
+def intercom(pub, flag) -> None:
+    """Behavior that will connect or disconnect rpi_out with mumble client."""
+    if flag is True:
+        pass  # set up intercom for rpi_out
+    else:
+        pass  # disconnect intercom
+    pub.publish(json.dumps(["intercom", False]))  # Change False to state of intercom
+
+def record(pub, flag) -> None:
+    """Behavior that will record a video, upload it to YouTube, and publish an URL to rpi_in."""
+    if flag is True:
+        # Start recording.
+        pub.publish(json.dumps(["record", True]))  # Will change button color, assuming video is being recorded.
+        # Once recording is over and YouTube gives link to playlist
+        pub.publish(json.dumps(["yt_playlist_link"]))
+    else:
+        pub.publish(json.dumps(["record", False]))  # Something went wrong
+
+def alarm(pub, flag) -> None:
+    """Behavior that will set off alarm on rpi_out."""
+    if flag is True:
+        pass  # A noise worse than death itself
+    else:
+        pass  # Tranquility

--- a/src/raspberry_pi_driver/behaviors.py
+++ b/src/raspberry_pi_driver/behaviors.py
@@ -24,10 +24,10 @@ def sample(msg_q, pub) -> None:
     pub.publish(json.dumps([identifier, flag]))
 
 def motion(pub, flag):
-    motion = MotionPIR(None, 23)
+    sensor = MotionPIR(None, 23)
     if flag is True:
-        motion.set_armed()
+        sensor.set_armed()
     else:
-        motion.set_disarmed()
-    pub.publish(json.dumps(["motion", motion.get_state()]))
+        sensor.set_disarmed()
+    pub.publish(json.dumps(["motion", sensor.get_state()]))
 

--- a/src/raspberry_pi_motion_sensor/motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/motion_interface.py
@@ -20,10 +20,6 @@ class MotionPir:
         self.armed = False
         self.queue = queue
         self.channel_num = channel_num
-
-        GPIO.setmode(
-            GPIO.BCM
-        )  # use GPIO.setmode(GPIO.board) for using pin numbers
         GPIO.setup(self.channel_num, GPIO.IN)
 
     def motion_callback(self, channel):

--- a/src/raspberry_pi_motion_sensor/motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/motion_interface.py
@@ -31,7 +31,7 @@ class MotionPir:
         """
 
         # Here, alternatively, an application / command can be started
-        # self.queue.put(True)
+        self.queue.put(True)
         print("Movement Detected")
 
     def set_armed(self):


### PR DESCRIPTION
json was imported into out_driver to get identifier from msg_q. RPi.GPIO is used to set the RPi board and cleanup. Removed the sample behavior from behaviors.py. Modified motion_interface.py to ignore the queue during callbacks for testing. motion button and intercom button work nicely, record has an issue in rokku.py where `type(self.yt_playlist_link)` on line 250 is a bool, causing a logger error message.
Edit: All tests passed upon commit.