### PR TITLE
Fanchen/change led indicator

### DIFF
--- a/rpi_out_driver.py
+++ b/rpi_out_driver.py
@@ -56,7 +56,8 @@ def main():
     # set up motion sensor
     motion_queue = Queue()  # set up queue for motion sensor
     motion_pin = 23  # channel 23 (GPIO23) is connected to motion sensor
-    sensor = MotionPir(motion_queue, motion_pin, motion_sensor_config)
+    led_pin = 12  # GPIO12 is connected to motion sensor LED indicator
+    sensor = MotionPir(motion_queue, motion_pin, led_pin, motion_sensor_config)
     led_proc = None  # placeholder for process lighting up LED.
 
     # Run mute button in separate process
@@ -81,8 +82,8 @@ def main():
                 elif identifier == "motion_ackd":
                     # User acknowledged motion has been detected.
                     # Resume motion sensor
-                    sensor.set_armed()
                     terminate_proc(led_proc, logger)
+                    sensor.set_armed()
 
             if not motion_queue.empty():  # motion detected
                 motion_queue.get()

--- a/src/raspberry_pi_intercom/togglemute_button.py
+++ b/src/raspberry_pi_intercom/togglemute_button.py
@@ -15,25 +15,26 @@ def togglemute(logger: logging.Logger) -> None:
     Mumble client mute when button is released (LED light also off).
     """
     GPIO.setmode(GPIO.BCM)
-
+    input_pin = 16
+    output_pin = 26
     # input pin connected to button. Button is pull up, meaning button press
     # sends logic low, while button release high
-    GPIO.setup(16, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    GPIO.setup(input_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
     # Output pin connected to LED. High leads to LED on, while low off.
-    GPIO.setup(12, GPIO.OUT)
+    GPIO.setup(output_pin, GPIO.OUT)
     mute: bool = True  # flag
 
     try:
         while True:
             input_state = GPIO.input(16)
             if input_state:  # input high, button released
-                GPIO.output(12, GPIO.LOW)  # turn off LED
+                GPIO.output(output_pin, GPIO.LOW)  # turn off LED
                 if not mute:
                     subprocess.run(shlex.split("mumble rpc mute"))  # mute
                     mute = True
                     logger.debug("Mumble client MUTE")
             else:  # input low, button pressed
-                GPIO.output(12, GPIO.HIGH)  # turn on LED
+                GPIO.output(output_pin, GPIO.HIGH)  # turn on LED
                 if mute:
                     subprocess.run(shlex.split("mumble rpc unmute"))  # unmute
                     mute = False

--- a/src/raspberry_pi_intercom/togglemute_button.py
+++ b/src/raspberry_pi_intercom/togglemute_button.py
@@ -26,7 +26,7 @@ def togglemute(logger: logging.Logger) -> None:
 
     try:
         while True:
-            input_state = GPIO.input(16)
+            input_state = GPIO.input(input_pin)
             if input_state:  # input high, button released
                 GPIO.output(output_pin, GPIO.LOW)  # turn off LED
                 if not mute:

--- a/src/raspberry_pi_motion_sensor/tests/conftest.py
+++ b/src/raspberry_pi_motion_sensor/tests/conftest.py
@@ -23,4 +23,5 @@ def motion_sensor():
     motion_sensor_config = app_config["motion_sensor"]
     motion_queue = Queue()
     motion_pin = 23
-    yield MotionPir(motion_queue, motion_pin, motion_sensor_config)
+    led_pin = 12
+    yield MotionPir(motion_queue, motion_pin, led_pin, motion_sensor_config)

--- a/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
+++ b/src/raspberry_pi_motion_sensor/tests/test_motion_interface.py
@@ -4,7 +4,7 @@ from time import sleep
 
 
 def test_init(motion_sensor):
-    assert motion_sensor.channel_num == 23
+    assert motion_sensor.motion_pin == 23
 
 
 def test_init_2(motion_sensor):


### PR DESCRIPTION
Enable two LED indicators on rpi_out. The red LED lights up when motion sensor is triggered. The blue LED lights up when microphone is on during intercom (i.e. blue LED lights up after visitor presses the button to talk back)